### PR TITLE
Fixed Fatal error:  Cannot redeclare class ArpService

### DIFF
--- a/modules/custom/os2web_acadre_esdh/plugins/cp/acadre.inc
+++ b/modules/custom/os2web_acadre_esdh/plugins/cp/acadre.inc
@@ -39,13 +39,22 @@ function os2web_acadre_esdh_cp_handle_request($ws_type = 'metadata') {
 #  }
 
   // Load ARP Service Class based on $ws_type argument.
-  module_load_include('inc', 'os2web_acadre_esdh', 'plugins/cp/' . $ws_type . '/ArpService.class');
+  switch ($ws_type) {
+    case 'metadata':
+      $class_name = 'ArpService';
+      break;
+
+    case 'file_transfer':
+      $class_name = 'ArpServiceFileTransfer';
+      break;
+  }
+  module_load_include('inc', 'os2web_acadre_esdh', 'plugins/cp/' . $ws_type . '/' . $class_name . '.class');
 
   if (isset($_GET['wsdl'])) {
-    ArpService::getWSDL($_GET['wsdl']);
+    $class_name::getWSDL($_GET['wsdl']);
   }
   if (isset($_GET['xsd'])) {
-    ArpService::getXSD($_GET['xsd']);
+    $class_name::getXSD($_GET['xsd']);
   }
   if (!lock_acquire(__FUNCTION__, 5)) {
     lock_wait(__FUNCTION__);
@@ -62,7 +71,7 @@ function os2web_acadre_esdh_cp_handle_request($ws_type = 'metadata') {
 
   ini_set("soap.wsdl_cache_enabled", "1");
   $server = new SoapServer('http' . ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? '' : '') . '://' . $_SERVER['SERVER_NAME'] . '/' . request_path() . '/?wsdl', array());
-  $server->setObject(new ArpService());
+  $server->setObject(new $class_name());
   $server->handle($data);
   lock_release(__FUNCTION__);
 }

--- a/modules/custom/os2web_acadre_esdh/plugins/cp/file_transfer/ArpServiceFileTransfer.class.inc
+++ b/modules/custom/os2web_acadre_esdh/plugins/cp/file_transfer/ArpServiceFileTransfer.class.inc
@@ -11,7 +11,7 @@
  * @TODO This object need should be refactored to interface and
  * implementation structure.
  */
-class ArpService {
+class ArpServiceFileTransfer {
   /**
    * Dumps the wsdl for the serivce.
    */

--- a/modules/custom/os2web_acadre_esdh/plugins/cp/metadata/ArpService.class.inc
+++ b/modules/custom/os2web_acadre_esdh/plugins/cp/metadata/ArpService.class.inc
@@ -55,14 +55,15 @@ class ArpService {
     $contents = fread($handle, filesize($filename));
     fclose($handle);
 
+    $contents = format_string($contents, array(
+      '!endpointurl' => 'http' . ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 's' : '') . '://' . $_SERVER['SERVER_NAME'] . '/' . request_path(),
+    ));
     drupal_add_http_header('Connection', 'close', FALSE);
     drupal_add_http_header('Content-Length', drupal_strlen($contents), TRUE);
     drupal_add_http_header('Content-Type', 'text/plain; charset=utf-8', TRUE);
     drupal_add_http_header('Date', date('r'), TRUE);
 
-    echo format_string($contents, array(
-      '!endpointurl' => 'http' . ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 's' : '') . '://' . $_SERVER['SERVER_NAME'] . '/' . request_path(),
-    ));
+    echo $contents;
     exit;
   }
 


### PR DESCRIPTION
In first implementation there was implemented two classes with the same name
`os2web_acadre_esdh/plugins/cp/metadata/ArpService.class.inc`

In this pull request it have been refactored to two different classes with proper names.
Implemented dynamic class call.